### PR TITLE
fix: requires aws-cdk-lib@^2 which is backward compatibility

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -104,7 +104,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.0.0",
+      "version": "^2",
       "type": "peer"
     },
     {
@@ -114,7 +114,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.0.0",
+      "version": "2",
       "type": "runtime"
     }
   ],

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -32,10 +32,10 @@ const project = new cdk.JsiiProject({
     },
   },
   deps: [
-    'aws-cdk-lib@2.0.0',
+    'aws-cdk-lib@2',
   ],
   peerDeps: [
-    'aws-cdk-lib@2.0.0',
+    'aws-cdk-lib@^2',
     'constructs@^10.0.5',
   ],
   devDeps: [
@@ -67,8 +67,7 @@ const sampleProject = new awscdk.AwsCdkTypeScriptApp({
   featureFlags: false,
   cdkDependencies: [],
   deps: [
-    'aws-cdk-lib@2.0.0',
-    'cdk-bootstrapless-synthesizer@^2.0.0',
+    'cdk-bootstrapless-synthesizer@^2',
     'constructs@^10.0.5',
   ], /* Runtime dependencies of this module. */
   // description: undefined,      /* The description is just a string that helps people understand the purpose of the package. */

--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
     "typescript": "^4.5.2"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.0.0",
+    "aws-cdk-lib": "^2",
     "constructs": "^10.0.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.0.0"
+    "aws-cdk-lib": "2"
   },
   "bundledDependencies": [],
   "keywords": [

--- a/sample/.projen/deps.json
+++ b/sample/.projen/deps.json
@@ -93,7 +93,7 @@
     },
     {
       "name": "cdk-bootstrapless-synthesizer",
-      "version": "^2.0.0",
+      "version": "^2",
       "type": "runtime"
     },
     {

--- a/sample/package.json
+++ b/sample/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@aws-cdk/assert": "2.0.0",
     "aws-cdk-lib": "2.0.0",
-    "cdk-bootstrapless-synthesizer": "^2.0.0",
+    "cdk-bootstrapless-synthesizer": "^2",
     "constructs": "^10.0.5"
   },
   "bundledDependencies": [],

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -1526,10 +1526,10 @@ cdk-assets@2.0.0:
     mime "^2.6.0"
     yargs "^16.2.0"
 
-cdk-bootstrapless-synthesizer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cdk-bootstrapless-synthesizer/-/cdk-bootstrapless-synthesizer-2.0.0.tgz#035199ce2f830dfe7ff7fd91a7417dc8675d206a"
-  integrity sha512-6nQy2GUMqBIP8fJkQ+85qDOJnY7Nu5oZVJQ5QtNxxIam7QdoZXYydY0VZ3oLvY5KNtS2VgWDXj/HtpSwi9rCGA==
+cdk-bootstrapless-synthesizer@^2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/cdk-bootstrapless-synthesizer/-/cdk-bootstrapless-synthesizer-2.0.2.tgz#bacb7bab2c1df0e7397ee857c1f4ee4e12c7e1f5"
+  integrity sha512-IvxkFWyMy13pX+hNMBurvwAiyELDERhakDJe7kFyHPc0QIGjjo1lEeKyAQr5WwMoQdjrXvs2oHbhUH3P0s1xcw==
   dependencies:
     aws-cdk-lib "2.0.0"
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { DockerImageAssetLocation, DockerImageAssetSource, FileAssetLocation, FileAssetPackaging, FileAssetSource, Fn, ISynthesisSession, Stack, StackSynthesizer, Token } from 'aws-cdk-lib';
 import * as cxschema from 'aws-cdk-lib/cloud-assembly-schema';
-import { DockerImageAssetLocation, DockerImageAssetSource, FileAssetLocation, FileAssetPackaging, FileAssetSource, Fn, ISynthesisSession, Stack, StackSynthesizer, Token } from 'aws-cdk-lib/core';
 import * as cxapi from 'aws-cdk-lib/cx-api';
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,10 +1132,10 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.0.0.tgz#da7cf476363771f5ce4eb2aa73388b91db50553e"
-  integrity sha512-ETom3THcblmS3GSoS6rb2AGy7HZpcpoHvwNlxeVIVbmGOiKrrqjvECK2uOJtNboV/vDTHHjx/s/1SwptLo9dlg==
+aws-cdk-lib@2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.1.0.tgz#2497484cfd4e2eeaba99b070bbfa54486d52ae34"
+  integrity sha512-W607G3aSrWpawpcqzIuUYKlU+grfvkbszyqikyVYqJgMHFCCQXq0S1ynPMzfQ49CwjlwZsu4LIsPM+dNR+Yj6g==
   dependencies:
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"


### PR DESCRIPTION
Previous v2 releases are pinned to `aws-cdk-lib@2.0.0` which makes incompatible when using newer v2 release(for example, v2.1.0).