### PR TITLE
fix: miss cross ecr pulling policy when processing nested stacks

### DIFF
--- a/src/aspect.ts
+++ b/src/aspect.ts
@@ -47,7 +47,8 @@ export abstract class ECRRepositoryAspect implements IAspect {
   }
 
   protected crossAccountECRPolicy(stack: Stack, repoName: string): Policy {
-    const policy = ECRRepositoryAspect._repoPolicies.get(repoName);
+    const id = `${stack.stackName}-${repoName}`;
+    const policy = ECRRepositoryAspect._repoPolicies.get(id);
     if (policy) {
       return policy;
     }
@@ -71,7 +72,7 @@ export abstract class ECRRepositoryAspect implements IAspect {
         }),
       ],
     });
-    ECRRepositoryAspect._repoPolicies.set(repoName, newPolicy);
+    ECRRepositoryAspect._repoPolicies.set(id, newPolicy);
     return newPolicy;
   }
 }


### PR DESCRIPTION
When processing the stacks with netsted stacks(the same stack based on different conditions), the cross account ECR policy does not attach to the targeted stacks. It also might generates some unwanted cross stacks export to other stacks.